### PR TITLE
Correct cache dir not found

### DIFF
--- a/tm-scala.yaml
+++ b/tm-scala.yaml
@@ -24,6 +24,7 @@ commands:
       - run:
           name: Preparing cache files
           command: |
+            mkdir -p ~/.ivy2/cache
             rm -fv ~/.ivy2/.sbt.ivy.lock
             find ~/.ivy2/cache -name "ivydata-*.properties" -print -delete
             find ~/.sbt        -name "*.lock"               -print -delete


### PR DESCRIPTION
If previous cache get outdated then getting the issue -> https://app.circleci.com/pipelines/github/teikametrics/anglerfish/2205/workflows/3a58b010-9153-4405-bd5d-4242c916d782/jobs/6258